### PR TITLE
Remove all network I/O from core

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -88,22 +88,22 @@ int transaction_send(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP)
 void transaction_free(lwm2m_transaction_t * transacP);
 
 // defined in management.c
-coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, struct sockaddr * fromAddr, socklen_t fromAddrLen, coap_packet_t * message, coap_packet_t * response);
+coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * fromAddr, size_t fromAddrLen, coap_packet_t * message, coap_packet_t * response);
 
 // defined in observe.c
-coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, struct sockaddr * fromAddr, socklen_t fromAddrLen, coap_packet_t * message, coap_packet_t * response);
-void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, struct sockaddr * fromAddr, socklen_t fromAddrLen);
+coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * fromAddr, size_t fromAddrLen, coap_packet_t * message, coap_packet_t * response);
+void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, uint8_t * fromAddr, size_t fromAddrLen);
 
 // defined in registration.c
-coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, struct sockaddr * fromAddr, socklen_t fromAddrLen, coap_packet_t * message, coap_packet_t * response);
+coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * fromAddr, size_t fromAddrLen, coap_packet_t * message, coap_packet_t * response);
 void registration_deregister(lwm2m_context_t * contextP, lwm2m_server_t * serverP);
 void prv_freeClient(lwm2m_client_t * clientP);
 
 // defined in packet.c
-coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, struct sockaddr * addr, socklen_t addrLen);
-coap_status_t buffer_send(int sock, uint8_t * buffer, size_t length, struct sockaddr * addr, socklen_t addrLen);
+coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, uint8_t * addr, size_t addrLen);
+coap_status_t buffer_send(int sock, uint8_t * buffer, size_t length, uint8_t * addr, size_t addrLen);
 
 // defined in observe.c
-void handle_observe_notify(lwm2m_context_t * contextP, struct sockaddr * fromAddr, socklen_t fromAddrLen, coap_packet_t * message);
+void handle_observe_notify(lwm2m_context_t * contextP, uint8_t * fromAddr, size_t fromAddrLen, coap_packet_t * message);
 
 #endif

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -164,70 +164,35 @@ int lwm2m_set_bootstrap_server(lwm2m_context_t * contextP,
 
 int lwm2m_add_server(lwm2m_context_t * contextP,
                      uint16_t shortID,
-                     char * host,
-                     uint16_t port,
+                     struct sockaddr * addr,
+                     socklen_t addrLen,
                      lwm2m_security_t * securityP)
 {
     lwm2m_server_t * serverP;
-    char portStr[6];
     int status = INTERNAL_SERVER_ERROR_5_00;
-    struct addrinfo hints;
-    struct addrinfo *servinfo = NULL;
-    struct addrinfo *p;
-    int sock;
-
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_DGRAM;
-
-    if (0 >= sprintf(portStr, "%hu", port)) return INTERNAL_SERVER_ERROR_5_00;
-    if (0 != getaddrinfo(host, portStr, &hints, &servinfo) || servinfo == NULL) return NOT_FOUND_4_04;
 
     serverP = (lwm2m_server_t *)malloc(sizeof(lwm2m_server_t));
     if (serverP != NULL)
     {
         memset(serverP, 0, sizeof(lwm2m_server_t));
-
         memcpy(&(serverP->security), securityP, sizeof(lwm2m_security_t));
         serverP->shortID = shortID;
-        serverP->port = port;
-        serverP->host = strdup(host);
-
-        // we test the various addresses
-        sock = -1;
-        for(p = servinfo ; p != NULL && sock == -1 ; p = p->ai_next)
+        serverP->addr = (struct sockaddr *)malloc(addrLen);
+        if (serverP->addr != NULL)
         {
-            sock = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
-            if (sock >= 0)
-            {
-                if (-1 == connect(sock, p->ai_addr, p->ai_addrlen))
-                {
-                    close(sock);
-                    sock = -1;
-                }
-            }
+            memcpy(serverP->addr, addr, addrLen);
+            serverP->addrLen = addrLen;
+
+            contextP->serverList = (lwm2m_server_t*)LWM2M_LIST_ADD(contextP->serverList, serverP);
+
+            status = 0;
         }
-        if (sock >= 0)
+        else
         {
-            serverP->addr = (struct sockaddr *)malloc(servinfo->ai_addrlen);
-            if (serverP->addr != NULL)
-            {
-                memcpy(serverP->addr, servinfo->ai_addr, servinfo->ai_addrlen);
-                serverP->addrLen = servinfo->ai_addrlen;
-
-                contextP->serverList = (lwm2m_server_t*)LWM2M_LIST_ADD(contextP->serverList, serverP);
-
-                status = 0;
-            }
-            else
-            {
-                free(serverP);
-            }
-            close(sock);
+            free(serverP);
         }
     }
 
-    freeaddrinfo(servinfo);
     return status;
 }
 #endif

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -42,16 +42,19 @@ lwm2m_context_t * lwm2m_init(int socket,
                              char * endpointName,
                              uint16_t numObject,
                              lwm2m_object_t * objectList[],
-                             buffer_send_func_t buffer_send_func)
+                             lwm2m_buffer_send_callback_t bufferSendCallback)
 {
     lwm2m_context_t * contextP;
+
+    if (NULL == bufferSendCallback)
+        return NULL;
 
     contextP = (lwm2m_context_t *)malloc(sizeof(lwm2m_context_t));
     if (NULL != contextP)
     {
         memset(contextP, 0, sizeof(lwm2m_context_t));
         contextP->socket = socket;
-        contextP->buffer_send_func = buffer_send_func;
+        contextP->bufferSendCallback = bufferSendCallback;
 #ifdef LWM2M_CLIENT_MODE
         contextP->endpointName = strdup(endpointName);
         if (contextP->endpointName == NULL)
@@ -171,7 +174,7 @@ int lwm2m_add_server(lwm2m_context_t * contextP,
                      lwm2m_security_t * securityP)
 {
     lwm2m_server_t * serverP;
-    int status = INTERNAL_SERVER_ERROR_5_00;
+    int status = COAP_500_INTERNAL_SERVER_ERROR;
 
     serverP = (lwm2m_server_t *)malloc(sizeof(lwm2m_server_t));
     if (serverP != NULL)

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -41,7 +41,8 @@ David Navarro <david.navarro@intel.com>
 lwm2m_context_t * lwm2m_init(int socket,
                              char * endpointName,
                              uint16_t numObject,
-                             lwm2m_object_t * objectList[])
+                             lwm2m_object_t * objectList[],
+                             buffer_send_func_t buffer_send_func)
 {
     lwm2m_context_t * contextP;
 
@@ -50,6 +51,7 @@ lwm2m_context_t * lwm2m_init(int socket,
     {
         memset(contextP, 0, sizeof(lwm2m_context_t));
         contextP->socket = socket;
+        contextP->buffer_send_func = buffer_send_func;
 #ifdef LWM2M_CLIENT_MODE
         contextP->endpointName = strdup(endpointName);
         if (contextP->endpointName == NULL)

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -166,8 +166,8 @@ int lwm2m_set_bootstrap_server(lwm2m_context_t * contextP,
 
 int lwm2m_add_server(lwm2m_context_t * contextP,
                      uint16_t shortID,
-                     struct sockaddr * addr,
-                     socklen_t addrLen,
+                     uint8_t * addr,
+                     size_t addrLen,
                      lwm2m_security_t * securityP)
 {
     lwm2m_server_t * serverP;
@@ -179,7 +179,7 @@ int lwm2m_add_server(lwm2m_context_t * contextP,
         memset(serverP, 0, sizeof(lwm2m_server_t));
         memcpy(&(serverP->security), securityP, sizeof(lwm2m_security_t));
         serverP->shortID = shortID;
-        serverP->addr = (struct sockaddr *)malloc(addrLen);
+        serverP->addr = (uint8_t *)malloc(addrLen);
         if (serverP->addr != NULL)
         {
             memcpy(serverP->addr, addr, addrLen);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -350,6 +350,8 @@ typedef struct _lwm2m_observed_
     lwm2m_watcher_t * watcherList;
 } lwm2m_observed_t;
 
+typedef coap_status_t (*buffer_send_func_t)(int, uint8_t *, size_t, struct sockaddr *, socklen_t);
+
 /*
  * LWM2M Context
  */
@@ -370,10 +372,12 @@ typedef struct
 #endif
     uint16_t          nextMID;
     lwm2m_transaction_t * transactionList;
+    // buffer send callback
+    buffer_send_func_t buffer_send_func;
 } lwm2m_context_t;
 
 // initialize a liblwm2m context. endpointName, numObject and objectList are ignored for pure servers.
-lwm2m_context_t * lwm2m_init(int socket, char * endpointName, uint16_t numObject, lwm2m_object_t * objectList[]);
+lwm2m_context_t * lwm2m_init(int socket, char * endpointName, uint16_t numObject, lwm2m_object_t * objectList[], buffer_send_func_t buffer_send_func);
 // close a liblwm2m context.
 void lwm2m_close(lwm2m_context_t * contextP);
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -34,8 +34,6 @@ David Navarro <david.navarro@intel.com>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <sys/time.h>
 
 // expose CoAP error codes to applications
@@ -226,8 +224,8 @@ typedef struct _lwm2m_server_
     struct _lwm2m_server_ * next;   // matches lwm2m_list_t::next
     uint16_t          shortID;      // matches lwm2m_list_t::id
     lwm2m_security_t  security;
-    struct sockaddr * addr;
-    socklen_t         addrLen;
+    uint8_t * addr;
+    size_t         addrLen;
     lwm2m_status_t    status;
     char *            location;
     uint16_t          mid;
@@ -285,8 +283,8 @@ typedef struct _lwm2m_client_
     struct _lwm2m_client_ * next;       // matches lwm2m_list_t::next
     uint16_t                internalID; // matches lwm2m_list_t::id
     char * name;
-    struct sockaddr * addr;
-    socklen_t         addrLen;
+    uint8_t * addr;
+    size_t         addrLen;
     lwm2m_client_object_t * objectList;
     lwm2m_observation_t * observationList;
 } lwm2m_client_t;
@@ -350,7 +348,7 @@ typedef struct _lwm2m_observed_
     lwm2m_watcher_t * watcherList;
 } lwm2m_observed_t;
 
-typedef coap_status_t (*buffer_send_func_t)(int, uint8_t *, size_t, struct sockaddr *, socklen_t);
+typedef coap_status_t (*buffer_send_func_t)(int, uint8_t *, size_t, uint8_t *, size_t);
 
 /*
  * LWM2M Context
@@ -384,11 +382,11 @@ void lwm2m_close(lwm2m_context_t * contextP);
 // perform any required pending operation and adjust timeoutP to the maximal time interval to wait.
 int lwm2m_step(lwm2m_context_t * contextP, struct timeval * timeoutP);
 // dispatch received data to liblwm2m
-int lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int length, struct sockaddr * fromAddr, socklen_t fromAddrLen);
+int lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int length, uint8_t * fromAddr, size_t fromAddrLen);
 
 #ifdef LWM2M_CLIENT_MODE
 int lwm2m_set_bootstrap_server(lwm2m_context_t * contextP, lwm2m_bootstrap_server_t * serverP);
-int lwm2m_add_server(lwm2m_context_t * contextP, uint16_t shortID, struct sockaddr *addr, socklen_t addrLen, lwm2m_security_t * securityP);
+int lwm2m_add_server(lwm2m_context_t * contextP, uint16_t shortID, uint8_t *addr, size_t addrLen, lwm2m_security_t * securityP);
 
 // send registration message to all known LWM2M Servers.
 int lwm2m_register(lwm2m_context_t * contextP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -38,6 +38,9 @@ David Navarro <david.navarro@intel.com>
 #include <sys/socket.h>
 #include <sys/time.h>
 
+// expose CoAP error codes to applications
+#include "externals/er-coap-13/er-coap-13.h"
+
 /*
  * Error code
  */
@@ -222,8 +225,6 @@ typedef struct _lwm2m_server_
 {
     struct _lwm2m_server_ * next;   // matches lwm2m_list_t::next
     uint16_t          shortID;      // matches lwm2m_list_t::id
-    uint16_t          port;
-    char *            host;
     lwm2m_security_t  security;
     struct sockaddr * addr;
     socklen_t         addrLen;
@@ -383,7 +384,7 @@ int lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int length
 
 #ifdef LWM2M_CLIENT_MODE
 int lwm2m_set_bootstrap_server(lwm2m_context_t * contextP, lwm2m_bootstrap_server_t * serverP);
-int lwm2m_add_server(lwm2m_context_t * contextP, uint16_t shortID, char * host, uint16_t port, lwm2m_security_t * securityP);
+int lwm2m_add_server(lwm2m_context_t * contextP, uint16_t shortID, struct sockaddr *addr, socklen_t addrLen, lwm2m_security_t * securityP);
 
 // send registration message to all known LWM2M Servers.
 int lwm2m_register(lwm2m_context_t * contextP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -36,12 +36,11 @@ David Navarro <david.navarro@intel.com>
 #include <stdbool.h>
 #include <sys/time.h>
 
-// expose CoAP error codes to applications
-#include "externals/er-coap-13/er-coap-13.h"
-
 /*
  * Error code
  */
+
+#define COAP_NO_ERROR                   (uint8_t)0x00
 
 #define COAP_201_CREATED                (uint8_t)0x41
 #define COAP_202_DELETED                (uint8_t)0x42
@@ -348,7 +347,7 @@ typedef struct _lwm2m_observed_
     lwm2m_watcher_t * watcherList;
 } lwm2m_observed_t;
 
-typedef coap_status_t (*buffer_send_func_t)(int, uint8_t *, size_t, uint8_t *, size_t);
+typedef uint8_t (*lwm2m_buffer_send_callback_t)(int, uint8_t *, size_t, uint8_t *, size_t);
 
 /*
  * LWM2M Context
@@ -373,11 +372,11 @@ typedef struct
     uint16_t          nextMID;
     lwm2m_transaction_t * transactionList;
     // buffer send callback
-    buffer_send_func_t buffer_send_func;
+    lwm2m_buffer_send_callback_t bufferSendCallback;
 } lwm2m_context_t;
 
 // initialize a liblwm2m context. endpointName, numObject and objectList are ignored for pure servers.
-lwm2m_context_t * lwm2m_init(int socket, char * endpointName, uint16_t numObject, lwm2m_object_t * objectList[], buffer_send_func_t buffer_send_func);
+lwm2m_context_t * lwm2m_init(int socket, char * endpointName, uint16_t numObject, lwm2m_object_t * objectList[], lwm2m_buffer_send_callback_t bufferSendCallback);
 // close a liblwm2m context.
 void lwm2m_close(lwm2m_context_t * contextP);
 

--- a/core/management.c
+++ b/core/management.c
@@ -35,8 +35,8 @@ David Navarro <david.navarro@intel.com>
 #ifdef LWM2M_CLIENT_MODE
 coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                                 lwm2m_uri_t * uriP,
-                                struct sockaddr * fromAddr,
-                                socklen_t fromAddrLen,
+                                uint8_t * fromAddr,
+                                size_t fromAddrLen,
                                 coap_packet_t * message,
                                 coap_packet_t * response)
 {

--- a/core/observe.c
+++ b/core/observe.c
@@ -115,8 +115,8 @@ static void prv_unlinkObserved(lwm2m_context_t * contextP,
 }
 
 static lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP,
-                                       struct sockaddr * fromAddr,
-                                       socklen_t fromAddrLen)
+                                       uint8_t * fromAddr,
+                                       size_t fromAddrLen)
 {
     lwm2m_server_t * targetP;
 
@@ -148,8 +148,8 @@ static lwm2m_watcher_t * prv_findWatcher(lwm2m_observed_t * observedP,
 
 coap_status_t handle_observe_request(lwm2m_context_t * contextP,
                                      lwm2m_uri_t * uriP,
-                                     struct sockaddr * fromAddr,
-                                     socklen_t fromAddrLen,
+                                     uint8_t * fromAddr,
+                                     size_t fromAddrLen,
                                      coap_packet_t * message,
                                      coap_packet_t * response)
 {
@@ -196,8 +196,8 @@ coap_status_t handle_observe_request(lwm2m_context_t * contextP,
 
 void cancel_observe(lwm2m_context_t * contextP,
                     uint16_t mid,
-                    struct sockaddr * fromAddr,
-                    socklen_t fromAddrLen)
+                    uint8_t * fromAddr,
+                    size_t fromAddrLen)
 {
     lwm2m_observed_t * observedP;
 
@@ -448,8 +448,8 @@ int lwm2m_observe_cancel(lwm2m_context_t * contextP,
 }
 
 void handle_observe_notify(lwm2m_context_t * contextP,
-                           struct sockaddr * fromAddr,
-                           socklen_t fromAddrLen,
+                           uint8_t * fromAddr,
+                           size_t fromAddrLen,
                            coap_packet_t * message)
 {
     uint8_t * tokenP;

--- a/core/packet.c
+++ b/core/packet.c
@@ -70,10 +70,10 @@ Contains code snippets which are:
 #include <stdio.h>
 
 
-static int prv_check_addr(struct sockaddr * leftAddr,
-                          socklen_t leftAddrLen,
-                          struct sockaddr * rightAddr,
-                          socklen_t rightAddrLen)
+static int prv_check_addr(uint8_t * leftAddr,
+                          size_t leftAddrLen,
+                          uint8_t * rightAddr,
+                          size_t rightAddrLen)
 {
     if (leftAddrLen != rightAddrLen) return 0;
 
@@ -83,8 +83,8 @@ static int prv_check_addr(struct sockaddr * leftAddr,
 }
 
 static void handle_reset(lwm2m_context_t * contextP,
-                         struct sockaddr * fromAddr,
-                         socklen_t fromAddrLen,
+                         uint8_t * fromAddr,
+                         size_t fromAddrLen,
                          coap_packet_t * message)
 {
 #ifdef LWM2M_CLIENT_MODE
@@ -94,12 +94,12 @@ static void handle_reset(lwm2m_context_t * contextP,
 
 static void handle_response(lwm2m_context_t * contextP,
                             lwm2m_transaction_t * transacP,
-                            struct sockaddr * fromAddr,
-                            socklen_t fromAddrLen,
+                            uint8_t * fromAddr,
+                            size_t fromAddrLen,
                             coap_packet_t * message)
 {
-    struct sockaddr * targetAddr;
-    socklen_t targetAddrLen;
+    uint8_t * targetAddr;
+    size_t targetAddrLen;
 
     switch (transacP->peerType)
     {
@@ -129,8 +129,8 @@ static void handle_response(lwm2m_context_t * contextP,
 }
 
 static coap_status_t handle_request(lwm2m_context_t * contextP,
-                                    struct sockaddr * fromAddr,
-                                    socklen_t fromAddrLen,
+                                    uint8_t * fromAddr,
+                                    size_t fromAddrLen,
                                     coap_packet_t * message,
                                     coap_packet_t * response)
 {
@@ -180,8 +180,8 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
 int lwm2m_handle_packet(lwm2m_context_t * contextP,
                         uint8_t * buffer,
                         int length,
-                        struct sockaddr * fromAddr,
-                        socklen_t fromAddrLen)
+                        uint8_t * fromAddr,
+                        size_t fromAddrLen)
 {
     coap_status_t coap_error_code = NO_ERROR;
     static coap_packet_t message[1];
@@ -335,8 +335,8 @@ int lwm2m_handle_packet(lwm2m_context_t * contextP,
 
 coap_status_t message_send(lwm2m_context_t * contextP,
                            coap_packet_t * message,
-                           struct sockaddr * addr,
-                           socklen_t addrLen)
+                           uint8_t * addr,
+                           size_t addrLen)
 {
     coap_status_t result = INTERNAL_SERVER_ERROR_5_00;
     uint8_t pktBuffer[COAP_MAX_PACKET_SIZE+1];

--- a/core/packet.c
+++ b/core/packet.c
@@ -345,10 +345,7 @@ coap_status_t message_send(lwm2m_context_t * contextP,
     pktBufferLen = coap_serialize_message(message, pktBuffer);
     if (0 != pktBufferLen)
     {
-        if (NULL != contextP->buffer_send_func)
-            result = contextP->buffer_send_func(contextP->socket, pktBuffer, pktBufferLen, addr, addrLen);
-        else
-            LOG("ERROR No buffer send callback registered\n");
+        result = contextP->bufferSendCallback(contextP->socket, pktBuffer, pktBufferLen, addr, addrLen);
     }
 
     return result;

--- a/core/registration.c
+++ b/core/registration.c
@@ -147,7 +147,7 @@ void registration_deregister(lwm2m_context_t * contextP,
     pktBufferLen = coap_serialize_message(message, pktBuffer);
     if (0 != pktBufferLen)
     {
-        contextP->buffer_send_func(contextP->socket, pktBuffer, pktBufferLen, serverP->addr, serverP->addrLen);
+        contextP->bufferSendCallback(contextP->socket, pktBuffer, pktBufferLen, serverP->addr, serverP->addrLen);
     }
 
     serverP->status = STATE_UNKNOWN;

--- a/core/registration.c
+++ b/core/registration.c
@@ -147,7 +147,7 @@ void registration_deregister(lwm2m_context_t * contextP,
     pktBufferLen = coap_serialize_message(message, pktBuffer);
     if (0 != pktBufferLen)
     {
-        coap_send_message(contextP->socket, serverP->addr, serverP->addrLen, pktBuffer, pktBufferLen);
+        contextP->buffer_send_func(contextP->socket, pktBuffer, pktBufferLen, serverP->addr, serverP->addrLen);
     }
 
     serverP->status = STATE_UNKNOWN;
@@ -337,8 +337,8 @@ static int prv_getLocationString(uint16_t id,
 
 coap_status_t handle_registration_request(lwm2m_context_t * contextP,
                                           lwm2m_uri_t * uriP,
-                                          struct sockaddr * fromAddr,
-                                          socklen_t fromAddrLen,
+                                          uint8_t * fromAddr,
+                                          size_t fromAddrLen,
                                           coap_packet_t * message,
                                           coap_packet_t * response)
 {
@@ -386,7 +386,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         }
         clientP->name = name;
         clientP->objectList = objects;
-        clientP->addr = (struct sockaddr *)malloc(fromAddrLen);
+        clientP->addr = (uint8_t *)malloc(fromAddrLen);
         if (clientP->addr == NULL)
         {
             prv_freeClient(clientP);

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -184,24 +184,17 @@ int transaction_send(lwm2m_context_t * contextP,
     {
     case ENDPOINT_CLIENT:
         LOG("Sending %d bytes\r\n", transacP->buffer_len);
-
-        if (NULL != contextP->buffer_send_func)
-            contextP->buffer_send_func(contextP->socket,
-                        transacP->buffer, transacP->buffer_len,
-                        ((lwm2m_client_t*)transacP->peerP)->addr, ((lwm2m_client_t*)transacP->peerP)->addrLen);
-        else
-            LOG("ERROR No buffer send callback registered\n");
+        contextP->bufferSendCallback(contextP->socket,
+                    transacP->buffer, transacP->buffer_len,
+                    ((lwm2m_client_t*)transacP->peerP)->addr, ((lwm2m_client_t*)transacP->peerP)->addrLen);
 
         break;
 
     case ENDPOINT_SERVER:
         LOG("Sending %d bytes\r\n", transacP->buffer_len);
-        if (NULL != contextP->buffer_send_func)
-            contextP->buffer_send_func(contextP->socket,
-                        transacP->buffer, transacP->buffer_len,
-                        ((lwm2m_server_t*)transacP->peerP)->addr, ((lwm2m_server_t*)transacP->peerP)->addrLen);
-        else
-            LOG("ERROR No buffer send callback registered\n");
+        contextP->bufferSendCallback(contextP->socket,
+                    transacP->buffer, transacP->buffer_len,
+                    ((lwm2m_server_t*)transacP->peerP)->addr, ((lwm2m_server_t*)transacP->peerP)->addrLen);
         break;
 
     case ENDPOINT_BOOTSTRAP:

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -184,16 +184,24 @@ int transaction_send(lwm2m_context_t * contextP,
     {
     case ENDPOINT_CLIENT:
         LOG("Sending %d bytes\r\n", transacP->buffer_len);
-        buffer_send(contextP->socket,
-                    transacP->buffer, transacP->buffer_len,
-                    ((lwm2m_client_t*)transacP->peerP)->addr, ((lwm2m_client_t*)transacP->peerP)->addrLen);
+
+        if (NULL != contextP->buffer_send_func)
+            contextP->buffer_send_func(contextP->socket,
+                        transacP->buffer, transacP->buffer_len,
+                        ((lwm2m_client_t*)transacP->peerP)->addr, ((lwm2m_client_t*)transacP->peerP)->addrLen);
+        else
+            LOG("ERROR No buffer send callback registered\n");
+
         break;
 
     case ENDPOINT_SERVER:
         LOG("Sending %d bytes\r\n", transacP->buffer_len);
-        buffer_send(contextP->socket,
-                    transacP->buffer, transacP->buffer_len,
-                    ((lwm2m_server_t*)transacP->peerP)->addr, ((lwm2m_server_t*)transacP->peerP)->addrLen);
+        if (NULL != contextP->buffer_send_func)
+            contextP->buffer_send_func(contextP->socket,
+                        transacP->buffer, transacP->buffer_len,
+                        ((lwm2m_server_t*)transacP->peerP)->addr, ((lwm2m_server_t*)transacP->peerP)->addrLen);
+        else
+            LOG("ERROR No buffer send callback registered\n");
         break;
 
     case ENDPOINT_BOOTSTRAP:

--- a/core/utils.c
+++ b/core/utils.c
@@ -32,6 +32,7 @@ David Navarro <david.navarro@intel.com>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 
 int lwm2m_PlainTextToInt64(char * buffer,
@@ -100,7 +101,7 @@ int lwm2m_int64ToPlainText(int64_t data,
     char string[32];
     int len;
 
-    len = snprintf(string, 32, "%ld", data);
+    len = snprintf(string, 32, "%" PRId64, data);
     if (len > 0)
     {
         *bufferP = (char *)malloc(len);

--- a/externals/er-coap-13/er-coap-13.c
+++ b/externals/er-coap-13/er-coap-13.c
@@ -484,12 +484,6 @@ coap_send_message(uip_ipaddr_t *addr, uint16_t port, uint8_t *data, uint16_t len
   memset(&udp_conn->ripaddr, 0, sizeof(udp_conn->ripaddr));
   udp_conn->rport = 0;
 }
-#else
-void
-coap_send_message(int sock, struct sockaddr *addr, socklen_t addrLen, uint8_t *data, uint16_t length)
-{
-    sendto(sock, data, length, 0, addr, addrLen);
-}
 #endif
 /*-----------------------------------------------------------------------------------*/
 coap_status_t

--- a/externals/er-coap-13/er-coap-13.h
+++ b/externals/er-coap-13/er-coap-13.h
@@ -46,7 +46,6 @@
 #include "contiki-net.h"
 #include "erbium.h"
 #else
-#include <netinet/in.h>
 #include <signal.h>
 #include <time.h>
 #endif
@@ -347,8 +346,6 @@ void coap_init_message(void *packet, coap_message_type_t type, uint8_t code, uin
 size_t coap_serialize_message(void *packet, uint8_t *buffer);
 #ifdef CONTIKI
 void coap_send_message(uip_ipaddr_t *addr, uint16_t port, uint8_t *data, uint16_t length);
-#else
-void coap_send_message(int sock, struct sockaddr *addr, socklen_t addrLen, uint8_t *data, uint16_t length);
 #endif
 coap_status_t coap_parse_message(void *request, uint8_t *data, uint16_t data_len);
 

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -71,7 +71,7 @@ void print_usage(void)
     fprintf(stderr, "Launch a LWM2M client.\r\n\n");
 }
 
-static coap_status_t prv_buffer_send(int sock,
+static uint8_t prv_buffer_send(int sock,
                           uint8_t * buffer,
                           size_t length,
                           uint8_t * addr,
@@ -84,10 +84,10 @@ static coap_status_t prv_buffer_send(int sock,
     while (offset != length)
     {
         nbSent = sendto(sock, buffer + offset, length - offset, 0, (struct sockaddr *)addr, addrLen);
-        if (nbSent == -1) return INTERNAL_SERVER_ERROR_5_00;
+        if (nbSent == -1) return COAP_500_INTERNAL_SERVER_ERROR;
         offset += nbSent;
     }
-    return NO_ERROR;
+    return COAP_NO_ERROR;
 }
 
 static void prv_output_buffer(uint8_t * buffer,
@@ -227,7 +227,7 @@ static int prv_add_server(lwm2m_context_t * contextP,
     struct addrinfo *servinfo = NULL;
     struct addrinfo *p;
     int sock;
-    int status = INTERNAL_SERVER_ERROR_5_00;
+    int status = COAP_500_INTERNAL_SERVER_ERROR;
     struct sockaddr *sa;
     socklen_t sl;
 
@@ -235,8 +235,8 @@ static int prv_add_server(lwm2m_context_t * contextP,
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
 
-    if (0 >= sprintf(portStr, "%hu", port)) return INTERNAL_SERVER_ERROR_5_00;
-    if (0 != getaddrinfo(host, portStr, &hints, &servinfo) || servinfo == NULL) return NOT_FOUND_4_04;
+    if (0 >= sprintf(portStr, "%hu", port)) return COAP_500_INTERNAL_SERVER_ERROR;
+    if (0 != getaddrinfo(host, portStr, &hints, &servinfo) || servinfo == NULL) return COAP_404_NOT_FOUND;
 
     // we test the various addresses
     sock = -1;

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -72,6 +72,25 @@ void print_usage(void)
     fprintf(stderr, "Launch a LWM2M client.\r\n\n");
 }
 
+static coap_status_t prv_buffer_send(int sock,
+                          uint8_t * buffer,
+                          size_t length,
+                          struct sockaddr * addr,
+                          socklen_t addrLen)
+{
+    size_t nbSent;
+    size_t offset;
+
+    offset = 0;
+    while (offset != length)
+    {
+        nbSent = sendto(sock, buffer + offset, length - offset, 0, addr, addrLen);
+        if (nbSent == -1) return INTERNAL_SERVER_ERROR_5_00;
+        offset += nbSent;
+    }
+    return NO_ERROR;
+}
+
 static void prv_output_buffer(uint8_t * buffer,
                               int length)
 {
@@ -287,7 +306,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    lwm2mH = lwm2m_init(socket, "testlwm2mclient", 2, objArray);
+    lwm2mH = lwm2m_init(socket, "testlwm2mclient", 2, objArray, prv_buffer_send);
     if (NULL == lwm2mH)
     {
         fprintf(stderr, "lwm2m_init() failed\r\n");

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -75,8 +75,8 @@ void print_usage(void)
 static coap_status_t prv_buffer_send(int sock,
                           uint8_t * buffer,
                           size_t length,
-                          struct sockaddr * addr,
-                          socklen_t addrLen)
+                          uint8_t * addr,
+                          size_t addrLen)
 {
     size_t nbSent;
     size_t offset;
@@ -84,7 +84,7 @@ static coap_status_t prv_buffer_send(int sock,
     offset = 0;
     while (offset != length)
     {
-        nbSent = sendto(sock, buffer + offset, length - offset, 0, addr, addrLen);
+        nbSent = sendto(sock, buffer + offset, length - offset, 0, (struct sockaddr *)addr, addrLen);
         if (nbSent == -1) return INTERNAL_SERVER_ERROR_5_00;
         offset += nbSent;
     }
@@ -258,7 +258,7 @@ static int prv_add_server(lwm2m_context_t * contextP,
     }
     if (sock >= 0)
     {
-        status = lwm2m_add_server(contextP, shortID, sa, sl, securityP);
+        status = lwm2m_add_server(contextP, shortID, (uint8_t *)sa, sl, securityP);
         if (status != 0)
             close(sock);
     }
@@ -393,7 +393,7 @@ int main(int argc, char *argv[])
                             ntohs(((struct sockaddr_in6*)&addr)->sin6_port));
                     prv_output_buffer(buffer, numBytes);
 
-                    lwm2m_handle_packet(lwm2mH, buffer, numBytes, (struct sockaddr *)&addr, addrLen);
+                    lwm2m_handle_packet(lwm2mH, buffer, numBytes, (uint8_t *)&addr, addrLen);
                 }
             }
             else if (FD_ISSET(STDIN_FILENO, &readfds))

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -180,7 +180,6 @@ static void prv_output_servers(char * buffer,
         char s[INET6_ADDRSTRLEN];
 
         fprintf(stdout, "Server ID %d:\r\n", targetP->shortID);
-        //fprintf(stdout, "\thost: \"%s\" port: %hu\r\n", targetP->host, targetP->port);
         fprintf(stdout, "\tstatus: ");
         switch(targetP->status)
         {

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -86,6 +86,24 @@ Contains code snippets which are:
 
 static int g_quit = 0;
 
+static coap_status_t prv_buffer_send(int sock,
+                          uint8_t * buffer,
+                          size_t length,
+                          struct sockaddr * addr,
+                          socklen_t addrLen)
+{
+    size_t nbSent;
+    size_t offset;
+
+    offset = 0;
+    while (offset != length)
+    {
+        nbSent = sendto(sock, buffer + offset, length - offset, 0, addr, addrLen);
+        if (nbSent == -1) return INTERNAL_SERVER_ERROR_5_00;
+        offset += nbSent;
+    }
+    return NO_ERROR;
+}
 
 static void prv_output_buffer(FILE * fd,
                               uint8_t * buffer,
@@ -539,7 +557,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    lwm2mH = lwm2m_init(socket, "testlwm2mserver", 0, NULL);
+    lwm2mH = lwm2m_init(socket, "testlwm2mserver", 0, NULL, prv_buffer_send);
     if (NULL == lwm2mH)
     {
         fprintf(stderr, "lwm2m_init() failed\r\n");

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -85,7 +85,7 @@ Contains code snippets which are:
 
 static int g_quit = 0;
 
-static coap_status_t prv_buffer_send(int sock,
+static uint8_t prv_buffer_send(int sock,
                           uint8_t * buffer,
                           size_t length,
                           uint8_t * addr,
@@ -98,10 +98,10 @@ static coap_status_t prv_buffer_send(int sock,
     while (offset != length)
     {
         nbSent = sendto(sock, buffer + offset, length - offset, 0, (struct sockaddr *)addr, addrLen);
-        if (nbSent == -1) return INTERNAL_SERVER_ERROR_5_00;
+        if (nbSent == -1) return COAP_500_INTERNAL_SERVER_ERROR;
         offset += nbSent;
     }
-    return NO_ERROR;
+    return COAP_NO_ERROR;
 }
 
 static void prv_output_buffer(FILE * fd,

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -89,8 +89,8 @@ static int g_quit = 0;
 static coap_status_t prv_buffer_send(int sock,
                           uint8_t * buffer,
                           size_t length,
-                          struct sockaddr * addr,
-                          socklen_t addrLen)
+                          uint8_t * addr,
+                          size_t addrLen)
 {
     size_t nbSent;
     size_t offset;
@@ -98,7 +98,7 @@ static coap_status_t prv_buffer_send(int sock,
     offset = 0;
     while (offset != length)
     {
-        nbSent = sendto(sock, buffer + offset, length - offset, 0, addr, addrLen);
+        nbSent = sendto(sock, buffer + offset, length - offset, 0, (struct sockaddr *)addr, addrLen);
         if (nbSent == -1) return INTERNAL_SERVER_ERROR_5_00;
         offset += nbSent;
     }
@@ -630,7 +630,7 @@ int main(int argc, char *argv[])
                             ntohs(((struct sockaddr_in6*)&addr)->sin6_port));
                     prv_output_buffer(stderr, buffer, numBytes);
 
-                    lwm2m_handle_packet(lwm2mH, buffer, numBytes, (struct sockaddr *)&addr, addrLen);
+                    lwm2m_handle_packet(lwm2mH, buffer, numBytes, (uint8_t *)&addr, addrLen);
                 }
             }
             else if (FD_ISSET(STDIN_FILENO, &readfds))


### PR DESCRIPTION
Currently, liblwm2m has the bulk of the network I/O in the application (select loop, socket creation, packet receive). But, DNS and packet transmission are still handled by the core.

These patches remove the remaining network functions from the core and remove the reliance on BSD socket headers.

The core handles three opaque variables for each connection:
        int socket, an identifier for the transport, never dereferenced by core
        uint8_t *addr + size_t addrLen, an opaque buffer used by the the application to identify a destination (this could be a struct sockaddr/socklen pair, or something entirely different like a telephone number for SMS).

Hopefully, it will now be easier to use liblwm2m on embedded targets without BSD sockets and to bind to high level languages which want to handle socket juggling themselves.

Adding DTLS between core and the network layer may be more straighforward also.
