### PR TITLE
removed useless include of dirent.h

### DIFF
--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -44,7 +44,6 @@ David Navarro <david.navarro@intel.com>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/stat.h>
-#include <dirent.h>
 #include <errno.h>
 #include <signal.h>
 

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -75,7 +75,6 @@ Contains code snippets which are:
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/stat.h>
-#include <dirent.h>
 #include <errno.h>
 #include <signal.h>
 


### PR DESCRIPTION
removed some unused #include which can frighten embedded developers :)
