### PR TITLE
mem leak in handle_request()

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -173,6 +173,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
         result = NO_ERROR;
     }
 
+    lwm2m_free( uriP);
     return result;
 }
 


### PR DESCRIPTION
I believe there's a memory leak in `handle_request()`: `lwm2m_decode_uri()` allocates and returns an URI object that isn't frees by `handle_request()`, and none of the other sub-functions seem to free it either.
