### PR TITLE
make lwm2mclient more non-IPv6 friendly

### DIFF
--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -158,7 +158,7 @@ int get_socket()
     struct addrinfo *p;
 
     memset(&hints, 0, sizeof hints);
-    hints.ai_family = PF_INET6;
+    hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_flags = AI_PASSIVE;
 


### PR DESCRIPTION
when using the lwm2mclient on a machine with no ipv6 support, it fails because it tries to get an _IPv6_ udp socket on port 5683 
