### PR TITLE
Send token on error message.

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -226,6 +226,9 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
                 lwm2m_free(response->payload);
                 response->payload = NULL;
                 response->payload_len = 0;
+            }else{
+                message->code = coap_error_code;
+                coap_error_code = message_send(contextP, response, fromSessionH);
             }
         }
         else


### PR DESCRIPTION
When en error occured on a CoAP request, the response does not contain the Token. It seems this is a bug.

See [CoAP specification](https://datatracker.ietf.org/doc/draft-ietf-core-coap/?include_text=1) :

_"**2.2.  Request/Response Model** ..._

```
   Client              Server       Client              Server
      |                  |             |                  |
      |   CON [0xbc90]   |             |   CON [0xbc91]   |
      | GET /temperature |             | GET /temperature |
      |   (Token 0x71)   |             |   (Token 0x72)   |
      +----------------->|             +----------------->|
      |                  |             |                  |
      |   ACK [0xbc90]   |             |   ACK [0xbc91]   |
      |   2.05 Content   |             |  4.04 Not Found  |
      |   (Token 0x71)   |             |   (Token 0x72)   |
      |     "22.5 C"     |             |   "Not found"    |
      |<-----------------+             |<-----------------+
      |                  |             |                  |
```

I propose this patch which change a very small amount of code, but maybe this is not the best way.
Probably the  `lwm2m_handle_packet` function should be refactored because it begins to be long, but I do not feel to change it :), I do not manage this part of code enough.
