### PR TITLE
do not use coap_get_mid.

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -158,7 +158,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
             else
             {
                 /* Unreliable NON requests are answered with a NON as well. */
-                coap_init_message(response, COAP_TYPE_NON, CONTENT_2_05, coap_get_mid());
+                coap_init_message(response, COAP_TYPE_NON, CONTENT_2_05, contextP->nextMID++);
             }
 
             /* mirror token */


### PR DESCRIPTION
Maybe this is a better way to use `contextP->nextMID++` to generate a new message ID instead of `coap_get_mid()`
